### PR TITLE
Cursed Civilian

### DIFF
--- a/game/roles/inno/cursed.role.js
+++ b/game/roles/inno/cursed.role.js
@@ -2,6 +2,10 @@ exports.name = "Cursed Civilian "
 exports.description = "will become werewolf on death"
 
 exports.on_death = function(kill_desc, game, me) {
-    game.masters.send(`<@${me.id}> was killed so they were turned into a werewolf`)
+  if (kill_desc.by == "w") {
+    game.masters.send(`<@${me.id}> was attacked by the werewolves! However, as they were a **Cursed Civilian**, they have now become a **Werewolf** and have joined the wolf pack.`)
     me.role = "wolf/werewolf"
+    return false // didn't die
+  }
+  return true // did die
 }


### PR DESCRIPTION
I was quite unhappy about this role. The Cursed Civilian should change into a werewolf when they are attacked by werewolves, not anytime! This is THE example why we want the Game Masters to have a confirmation thing of the bot.

Also, as the on_death-function didn't have a return thing in it - would it actually change the player? Or would it make them dead, give 'em the dead participant role, THEN turn 'em back to a werewolf, giving them access to all cc's and allow them to talk with the dead people in graveyard?